### PR TITLE
Open Remote Desktop for a windows VM (kubevirt)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -207,6 +207,7 @@
         <script src="scripts/services/homePagePreference.js"></script>
         <script src="scripts/services/hpa.js"></script>
         <script src="scripts/services/pods.js"></script>
+        <script src="scripts/services/rdp.js"></script>
         <script src="scripts/services/templates.js"></script>
         <script src="scripts/services/secrets.js"></script>
         <script src="scripts/services/services.js"></script>

--- a/app/scripts/services/rdp.js
+++ b/app/scripts/services/rdp.js
@@ -1,0 +1,109 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .factory("RdpService", function(Logger) {
+    function findRDPPort (service, rdpPortNumber) {
+      var servicePorts = _.get(service, 'spec.ports');
+      return _.find(servicePorts, {targetPort: rdpPortNumber});
+    }
+
+    return {
+      buildRdp: function (address, port) {
+        return '' +
+          'full address:s:' + address + ':' + port +
+          '\nusername:s:Administrator' +
+          '\nscreen mode id:i:2' + // set 2 for full screen
+          '\nprompt for credentials:i:1' +
+          '\ndesktopwidth:i:0' +
+          '\ndesktopheight:i:0' +
+          '\nauthentication level:i:2' +
+          '\nredirectclipboard:i:1' +
+          '\nsession bpp:i:32' +
+          '\ncompression:i:1' +
+          '\nkeyboardhook:i:2' +
+          '\naudiocapturemode:i:0' +
+          '\nvideoplaybackmode:i:1' +
+          '\nconnection type:i:2' +
+          '\ndisplayconnectionbar:i:1' +
+          '\ndisable wallpaper:i:1' +
+          '\nallow font smoothing:i:1' +
+          '\nallow desktop composition:i:0' +
+          '\ndisable full window drag:i:1' +
+          '\ndisable menu anims:i:1' +
+          '\ndisable themes:i:0' +
+          '\ndisable cursor setting:i:0' +
+          '\nbitmapcachepersistenable:i:1' +
+          '\naudiomode:i:0' +
+          '\nredirectcomports:i:0' +
+          '\nredirectposdevices:i:0' +
+          '\nredirectdirectx:i:1' +
+          '\nautoreconnection enabled:i:1' +
+          '\nnegotiate security layer:i:1' +
+          '\nremoteapplicationmode:i:0' +
+          '\nalternate shell:s:' +
+          '\nshell working directory:s:' +
+          '\ngatewayhostname:s:' +
+          '\ngatewayusagemethod:i:4' +
+          '\ngatewaycredentialssource:i:4' +
+          '\ngatewayprofileusagemethod:i:0' +
+          '\npromptcredentialonce:i:1' +
+          '\nuse redirection server name:i:0' +
+          '\n';
+      },
+
+      fileDownload: function (data, fileName, mimeType) {
+        fileName = fileName || "vm.rdp";
+        mimeType = mimeType || "application/rdp";
+
+        var blob = new Blob([data], { type: mimeType });
+        saveAs(blob, fileName);
+      },
+
+      findRDPPort: findRDPPort,
+
+      getAddressPort: function (service, ovm, rdpPortNumber) {
+        var rdpPortObj = findRDPPort(service, rdpPortNumber);
+        if (!rdpPortObj) {
+          return null;
+        }
+
+        var type = _.get(service, 'spec.type');
+        var port = _.get(rdpPortObj, "port");
+        var address;
+        switch (type) {
+          case 'LoadBalancer':
+            address = _.get(service, 'spec.externalIPs[0]');
+            if (!address) {
+              Logger.warn("External IP is not defined for the LoadBalancer RDP Service: ", service, ovm);
+              return null;
+            }
+            break;
+          case 'ClusterIP':
+            address = _.get(service, 'spec.clusterIP');
+            if (!address) {
+              Logger.warn("Cluster IP is not defined for the ClusterIP RDP Service: ", service, ovm);
+              return null;
+            }
+            break;
+          case 'NodePort':
+            // TODO: Once verified, Service's nodeIP shall be used. Until then, IP from vm-pod-node is more safe
+            address = _.get(ovm, '_pod.status.hostIP');
+            if (!address) {
+              Logger.warn("Node IP (pod.status.hostIP) is not yet known, using NodePort RDP Service: ", service, ovm);
+              return null;
+            }
+            break;
+          default:
+            console.error('Unrecognized Service type: ', service);
+            return null;
+        }
+
+        Logger.info('RDP requested for: ', address, port, type);
+        return {
+          address: address,
+          port: port
+        };
+      }
+
+  };
+  });

--- a/app/views/overview/_virtual-machine-row.html
+++ b/app/views/overview/_virtual-machine-row.html
@@ -70,6 +70,14 @@
         <span class="vm-detail-value">{{ row.apiObject._pod | vmPodUptime }}</span>
       </div>
 
+      <div class="word-break" ng-if="row.isWindowsVM() && row.isOvmInRunningPhase()">
+        <span class="vm-detail-key">Remote Desktop:</span>
+        <span class="vm-detail-value">
+          <a href="" ng-if="row.isRdpService()" ng-click="row.onOpenRemoteDesktop()">Open Console</a>
+            <div ng-if="!row.isRdpService()">No RDP service defined</div>
+        </span>
+      </div>
+
       <div class="word-break">
         <span class="vm-detail-key">Operating System:</span>
         <span class="vm-detail-value">{{row.apiObject.metadata.labels['kubevirt.io/os'] || '--'}}</span>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1,20 +1,20 @@
 "use strict";
 
 function OverviewController(e, t, n, r, a, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b, S, C, w, P, j, k, I, R, E, T, N) {
-function A(e) {
+function D(e) {
 var t = e.metadata.ownerReferences;
 return t ? _(t).filter({
 kind: "OfflineVirtualMachine"
 }).map("uid").first() : null;
 }
-function D() {
+function A() {
 if (B.offlineVirtualMachines && B.virtualMachines && B.pods) {
 var e = _(B.pods).values().filter(function(e) {
 return !!_.get(e, 'metadata.labels["kubevirt.io/vmUID"]');
 }).keyBy('metadata.labels["kubevirt.io/vmUID"]').value(), t = _(B.virtualMachines).values().filter(function(e) {
-return !!A(e);
+return !!D(e);
 }).keyBy(function(e) {
-return A(e);
+return D(e);
 }).value(), n = [];
 _.each(B.offlineVirtualMachines, function(r) {
 var a = r.metadata.uid, o = t[a];
@@ -130,14 +130,14 @@ return _.isEmpty(be.pipelinesByDeploymentConfig[t]);
 B.deploymentConfigsNoPipeline = _.sortBy(e, "metadata.name"), B.pipelineViewHasOtherResources = !(_.isEmpty(B.deploymentConfigsNoPipeline) && _.isEmpty(B.vanillaReplicationControllers) && _.isEmpty(B.deployments) && _.isEmpty(B.vanillaReplicaSets) && _.isEmpty(B.statefulSets) && _.isEmpty(B.monopods));
 }, Ne = function() {
 B.disableFilter = "pipeline" === B.viewBy && _.isEmpty(B.pipelineBuildConfigs);
-}, Ae = function(e) {
+}, De = function(e) {
 return b.getLabelSelector().select(e);
-}, De = [ "metadata.name", "spec.clusterServiceClassExternalName" ], $e = function(e) {
-return y.filterForKeywords(e, De, be.filterKeywords);
+}, Ae = [ "metadata.name", "spec.clusterServiceClassExternalName" ], $e = function(e) {
+return y.filterForKeywords(e, Ae, be.filterKeywords);
 }, Be = function(e) {
 switch (B.filterBy) {
 case "label":
-return Ae(e);
+return De(e);
 
 case "name":
 return $e(e);
@@ -157,7 +157,7 @@ B.filteredDeploymentConfigs = Be(B.deploymentConfigs), B.filteredReplicationCont
 B.viewBy = localStorage.getItem(Oe) || "app", e.$watch(function() {
 return B.viewBy;
 }, function(e) {
-localStorage.setItem(Oe, e), Ne(), De = "app" === B.viewBy ? [ "metadata.name", "metadata.labels.app" ] : [ "metadata.name" ], Le(), "pipeline" === B.viewBy ? b.setLabelSuggestions(he) : b.setLabelSuggestions(ve);
+localStorage.setItem(Oe, e), Ne(), Ae = "app" === B.viewBy ? [ "metadata.name", "metadata.labels.app" ] : [ "metadata.name" ], Le(), "pipeline" === B.viewBy ? b.setLabelSuggestions(he) : b.setLabelSuggestions(ve);
 }), d.DISABLE_OVERVIEW_METRICS || (C.isAvailable(!0).then(function(e) {
 be.showMetrics = e;
 }), e.$on("metrics-connection-failed", function(e, t) {
@@ -240,7 +240,7 @@ _.isEmpty(e) || (b.addLabelSuggestionsFromResources(e, he), "pipeline" === B.vie
 }, nt = function(e) {
 return "Succeeded" !== e.status.phase && "Failed" !== e.status.phase && (!H(e, "openshift.io/deployer-pod-for.name") && (!O(e, "openshift.io/build.name") && "slave" !== H(e, "jenkins")));
 }, rt = function() {
-be.podsByOwnerUID = j.groupByOwnerUID(B.pods), B.monopods = _.filter(be.podsByOwnerUID[""], nt), D();
+be.podsByOwnerUID = j.groupByOwnerUID(B.pods), B.monopods = _.filter(be.podsByOwnerUID[""], nt), A();
 }, at = function(e) {
 return !!_.get(e, "status.replicas") || (!O(e, "deploymentConfig") || x(e));
 }, ot = function(e) {
@@ -285,19 +285,30 @@ e.matches(r) && t.push(be.allServices[n]);
 }), be.servicesByObjectUID[n] = _.sortBy(t, "metadata.name");
 });
 }, dt = function() {
+B.offlineVirtualMachines && be.allServices && _.each(B.offlineVirtualMachines, function(e) {
+var t = _.get(e, [ "metadata", "labels", "kubevirt.io/domain" ]);
+t && (e.services = _.filter(be.allServices, {
+spec: {
+selector: {
+"kubevirt.io/domain": t
+}
+}
+}));
+});
+}, mt = function() {
 if (be.allServices) {
 lt = _.mapValues(be.allServices, function(e) {
 return new LabelSelector(e.spec.selector);
 });
 var e = [ B.deploymentConfigs, B.vanillaReplicationControllers, B.deployments, B.vanillaReplicaSets, B.statefulSets, B.daemonSets, B.monopods ];
-_.each(e, ut), Re();
+_.each(e, ut), Re(), dt();
 }
-}, mt = function() {
+}, pt = function() {
 var e = E.groupByService(B.routes, !0);
 be.routesByService = _.mapValues(e, E.sortRoutesByScore), Re();
-}, pt = function() {
+}, ft = function() {
 be.hpaByResource = g.groupHPAs(B.horizontalPodAutoscalers);
-}, ft = function(e) {
+}, gt = function(e) {
 var t = F(e), n = B.buildConfigs[t];
 if (n) {
 B.recentPipelinesByBuildConfig[t] = B.recentPipelinesByBuildConfig[t] || [], B.recentPipelinesByBuildConfig[t].push(e);
@@ -306,23 +317,23 @@ _.each(r, function(t) {
 be.recentPipelinesByDeploymentConfig[t] = be.recentPipelinesByDeploymentConfig[t] || [], be.recentPipelinesByDeploymentConfig[t].push(e);
 }), Te();
 }
-}, gt = {}, vt = function() {
-gt = l.groupBuildConfigsByOutputImage(B.buildConfigs);
-}, ht = function(e) {
+}, vt = {}, ht = function() {
+vt = l.groupBuildConfigsByOutputImage(B.buildConfigs);
+}, yt = function(e) {
 var t = _e(e);
 if (t) return _.get(be, [ "buildConfigsByObjectUID", t ], []);
-}, yt = function(e) {
-var t = [], n = ht(e);
+}, bt = function(e) {
+var t = [], n = yt(e);
 _.each(n, function(e) {
 var n = _.get(be, [ "recentBuildsByBuildConfig", e.metadata.name ], []);
 t = t.concat(n);
 });
 var r = Ce(e);
 _.set(be, [ "recentBuildsByDeploymentConfig", r ], t);
-}, bt = function(e, t) {
+}, St = function(e, t) {
 var n = _e(t);
 n && _.set(be, [ "buildConfigsByObjectUID", n ], e);
-}, St = function() {
+}, Ct = function() {
 var e = [];
 B.deploymentConfigsByPipeline = {}, be.pipelinesByDeploymentConfig = {}, _.each(B.buildConfigs, function(t) {
 if (q(t)) {
@@ -333,37 +344,37 @@ be.pipelinesByDeploymentConfig[e] = be.pipelinesByDeploymentConfig[e] || [], be.
 });
 }
 }), B.pipelineBuildConfigs = _.sortBy(e, "metadata.name"), Te(), tt(B.pipelineBuildConfigs), Ne();
-}, Ct = function() {
+}, _t = function() {
 be.buildConfigsByObjectUID = {}, _.each(B.deploymentConfigs, function(e) {
 var t = [], n = _.get(e, "spec.triggers");
 _.each(n, function(n) {
 var r = _.get(n, "imageChangeParams.from");
 if (r) {
-var a = M(r, e.metadata.namespace), o = gt[a];
+var a = M(r, e.metadata.namespace), o = vt[a];
 _.isEmpty(o) || (t = t.concat(o));
 }
-}), t = _.sortBy(t, "metadata.name"), bt(t, e), yt(e);
+}), t = _.sortBy(t, "metadata.name"), St(t, e), bt(e);
 });
-}, _t = function() {
-St(), Ct();
 }, wt = function() {
-_.each(B.deploymentConfigs, yt);
+Ct(), _t();
 }, Pt = function() {
+_.each(B.deploymentConfigs, bt);
+}, jt = function() {
 if (be.builds && B.buildConfigs) {
 B.recentPipelinesByBuildConfig = {}, be.recentBuildsByBuildConfig = {}, be.recentPipelinesByDeploymentConfig = {};
 var e = {};
 _.each(l.interestingBuilds(be.builds), function(t) {
 var n = F(t);
-q(t) ? ft(t) : (e[n] = e[n] || [], e[n].push(t));
+q(t) ? gt(t) : (e[n] = e[n] || [], e[n].push(t));
 }), B.recentPipelinesByBuildConfig = _.mapValues(B.recentPipelinesByBuildConfig, function(e) {
 return l.sortBuilds(e, !0);
 }), be.recentPipelinesByDeploymentConfig = _.mapValues(be.recentPipelinesByDeploymentConfig, function(e) {
 return l.sortBuilds(e, !0);
 }), be.recentBuildsByBuildConfig = _.mapValues(e, function(e) {
 return l.sortBuilds(e, !0);
-}), wt();
+}), Pt();
 }
-}, jt = function() {
+}, kt = function() {
 R.setQuotaNotifications(be.quotas, be.clusterQuotas, a.project);
 };
 B.clearFilter = function() {
@@ -383,7 +394,7 @@ w.toProjectCatalog(e.projectName);
 }, b.onActiveFiltersChanged(function() {
 e.$evalAsync(Le);
 }), B.startBuild = l.startBuild;
-var kt = function() {
+var It = function() {
 if (be.bindingsByApplicationUID = {}, be.applicationsByBinding = {}, be.deleteableBindingsByApplicationUID = {}, !_.isEmpty(be.bindings)) {
 var e = [ B.deployments, B.deploymentConfigs, B.vanillaReplicationControllers, B.vanillaReplicaSets, B.statefulSets, B.daemonSets ];
 if (!_.some(e, function(e) {
@@ -405,19 +416,19 @@ return _.get(_.head(t), [ "metadata", "name" ]) || e.metadata.name;
 }, {});
 }
 }
-}, It = function() {
+}, Rt = function() {
 be.bindableServiceInstances = c.filterBindableServiceInstances(be.serviceInstances, be.serviceClasses, be.servicePlans), be.orderedServiceInstances = c.sortServiceInstances(be.serviceInstances, be.serviceClasses);
-}, Rt = [], Et = L ? {
+}, Et = [], Tt = L ? {
 skipErrorNotFound: !0
 } : {};
-k.get(a.project, Et).then(_.spread(function(t, r) {
+k.get(a.project, Tt).then(_.spread(function(t, r) {
 be.project = e.project = t, be.context = e.context = r;
 var a = function() {
 B.pods && h.fetchReferencedImageStreamImages(B.pods, be.imagesByDockerReference, be.imageStreamImageRefByDockerReference, r);
 }, o = function(e) {
-B.daemonSets = e.by("metadata.name"), ut(B.daemonSetData), ut(B.monopods), ze(B.daemonSets), et(B.daemonSets), kt(), Le(), S.log("daemonsets", B.daemonSets);
+B.daemonSets = e.by("metadata.name"), ut(B.daemonSetData), ut(B.monopods), ze(B.daemonSets), et(B.daemonSets), It(), Le(), S.log("daemonsets", B.daemonSets);
 }, i = !1, s = function() {
-i || (Rt.push(m.watch(J, r, o, {
+i || (Et.push(m.watch(J, r, o, {
 poll: V,
 pollInterval: 6e4
 })), i = !0);
@@ -430,61 +441,61 @@ kind: "DaemonSet"
 }, l = function() {
 i || _.some(B.pods, c) && s();
 };
-if (Rt.push(m.watch(ne, r, function(e, t) {
+if (Et.push(m.watch(ne, r, function(e, t) {
 B.pods = e.by("metadata.name"), rt(), a(), Xe(), ut(B.monopods), ze(B.monopods), et(B.monopods), Le(), t && "ADDED" !== t || l(), S.log("pods (subscribe)", B.pods);
-})), Rt.push(m.watch(ae, r, function(e) {
-B.replicationControllers = e.by("metadata.name"), it(), ut(B.vanillaReplicationControllers), ut(B.monopods), ze(B.vanillaReplicationControllers), et(B.vanillaReplicationControllers), kt(), Le(), S.log("replicationcontrollers (subscribe)", B.replicationControllers);
-})), Rt.push(m.watch(Y, r, function(e) {
-B.deploymentConfigs = e.by("metadata.name"), it(), ut(B.deploymentConfigs), ut(B.vanillaReplicationControllers), et(B.deploymentConfigs), Ye(), _t(), wt(), kt(), Le(), S.log("deploymentconfigs (subscribe)", B.deploymentConfigs);
-})), Rt.push(m.watch(re, r, function(e) {
-B.replicaSets = e.by("metadata.name"), ct(), ut(B.vanillaReplicaSets), ut(B.monopods), ze(B.vanillaReplicaSets), et(B.vanillaReplicaSets), kt(), Le(), S.log("replicasets (subscribe)", B.replicaSets);
-})), Rt.push(m.watch(Z, r, function(e) {
-fe = e.by("metadata.uid"), B.deployments = _.sortBy(fe, "metadata.name"), ct(), ut(B.deployments), ut(B.vanillaReplicaSets), et(B.deployments), kt(), Le(), S.log("deployments (subscribe)", B.deploymentsByUID);
-})), Rt.push(m.watch(W, r, function(e) {
-be.builds = e.by("metadata.name"), Pt(), S.log("builds (subscribe)", be.builds);
-})), Rt.push(m.watch(me, r, function(e) {
-B.statefulSets = e.by("metadata.name"), ut(B.statefulSets), ut(B.monopods), ze(B.statefulSets), et(B.statefulSets), kt(), Le(), S.log("statefulsets (subscribe)", B.statefulSets);
+})), Et.push(m.watch(ae, r, function(e) {
+B.replicationControllers = e.by("metadata.name"), it(), ut(B.vanillaReplicationControllers), ut(B.monopods), ze(B.vanillaReplicationControllers), et(B.vanillaReplicationControllers), It(), Le(), S.log("replicationcontrollers (subscribe)", B.replicationControllers);
+})), Et.push(m.watch(Y, r, function(e) {
+B.deploymentConfigs = e.by("metadata.name"), it(), ut(B.deploymentConfigs), ut(B.vanillaReplicationControllers), et(B.deploymentConfigs), Ye(), wt(), Pt(), It(), Le(), S.log("deploymentconfigs (subscribe)", B.deploymentConfigs);
+})), Et.push(m.watch(re, r, function(e) {
+B.replicaSets = e.by("metadata.name"), ct(), ut(B.vanillaReplicaSets), ut(B.monopods), ze(B.vanillaReplicaSets), et(B.vanillaReplicaSets), It(), Le(), S.log("replicasets (subscribe)", B.replicaSets);
+})), Et.push(m.watch(Z, r, function(e) {
+fe = e.by("metadata.uid"), B.deployments = _.sortBy(fe, "metadata.name"), ct(), ut(B.deployments), ut(B.vanillaReplicaSets), et(B.deployments), It(), Le(), S.log("deployments (subscribe)", B.deploymentsByUID);
+})), Et.push(m.watch(W, r, function(e) {
+be.builds = e.by("metadata.name"), jt(), S.log("builds (subscribe)", be.builds);
+})), Et.push(m.watch(me, r, function(e) {
+B.statefulSets = e.by("metadata.name"), ut(B.statefulSets), ut(B.monopods), ze(B.statefulSets), et(B.statefulSets), It(), Le(), S.log("statefulsets (subscribe)", B.statefulSets);
 }, {
 poll: V,
 pollInterval: 6e4
 })), m.list(J, r, function(e) {
 o(e), _.isEmpty(B.daemonSets) || s();
-}), Rt.push(m.watch(de, r, function(e) {
-be.allServices = e.by("metadata.name"), dt(), S.log("services (subscribe)", be.allServices);
+}), Et.push(m.watch(de, r, function(e) {
+be.allServices = e.by("metadata.name"), mt(), S.log("services (subscribe)", be.allServices);
 }, {
 poll: V,
 pollInterval: 6e4
-})), Rt.push(m.watch(ie, r, function(e) {
-B.routes = e.by("metadata.name"), mt(), S.log("routes (subscribe)", B.routes);
+})), Et.push(m.watch(ie, r, function(e) {
+B.routes = e.by("metadata.name"), pt(), S.log("routes (subscribe)", B.routes);
 }, {
 poll: V,
 pollInterval: 6e4
-})), Rt.push(m.watch(K, r, function(e) {
-B.buildConfigs = e.by("metadata.name"), vt(), _t(), Pt(), Le(), S.log("buildconfigs (subscribe)", B.buildConfigs);
+})), Et.push(m.watch(K, r, function(e) {
+B.buildConfigs = e.by("metadata.name"), ht(), wt(), jt(), Le(), S.log("buildconfigs (subscribe)", B.buildConfigs);
 }, {
 poll: V,
 pollInterval: 6e4
-})), Rt.push(m.watch(X, r, function(e) {
-B.horizontalPodAutoscalers = e.by("metadata.name"), pt(), S.log("autoscalers (subscribe)", B.horizontalPodAutoscalers);
+})), Et.push(m.watch(X, r, function(e) {
+B.horizontalPodAutoscalers = e.by("metadata.name"), ft(), S.log("autoscalers (subscribe)", B.horizontalPodAutoscalers);
 }, {
 poll: V,
 pollInterval: 6e4
-})), Rt.push(m.watch(ee, r, function(e) {
+})), Et.push(m.watch(ee, r, function(e) {
 ge = e.by("metadata.name"), h.buildDockerRefMapForImageStreams(ge, be.imageStreamImageRefByDockerReference), a(), S.log("imagestreams (subscribe)", ge);
 }, {
 poll: V,
 pollInterval: 6e4
-})), Rt.push(m.watch(oe, r, function(e) {
-be.quotas = e.by("metadata.name"), jt();
+})), Et.push(m.watch(oe, r, function(e) {
+be.quotas = e.by("metadata.name"), kt();
 }, {
 poll: !0,
 pollInterval: 6e4
-})), Rt.push(m.watch(Q, r, function(e) {
-be.clusterQuotas = e.by("metadata.name"), jt();
+})), Et.push(m.watch(Q, r, function(e) {
+be.clusterQuotas = e.by("metadata.name"), kt();
 }, {
 poll: !0,
 pollInterval: 6e4
-})), e.AEROGEAR_MOBILE_ENABLED && Rt.push(m.watch({
+})), e.AEROGEAR_MOBILE_ENABLED && Et.push(m.watch({
 group: "mobile.k8s.io",
 version: "v1alpha1",
 resource: "mobileclients"
@@ -494,14 +505,14 @@ B.mobileClients = e.by("metadata.name"), Le(), S.log("mobileclients (subscribe)"
 poll: V,
 pollInterval: 6e4
 })), e.KUBEVIRT_ENABLED) {
-Rt.push(m.watch(N.offlineVirtualMachine, r, function(e) {
-B.offlineVirtualMachines = e.by("metadata.name"), D(), Le();
+Et.push(m.watch(N.offlineVirtualMachine, r, function(e) {
+B.offlineVirtualMachines = e.by("metadata.name"), A(), dt(), Le();
 }, {
 poll: V,
 pollInterval: 6e4
 }));
-Rt.push(m.watch(N.virtualMachine, r, function(e) {
-B.virtualMachines = e.by("metadata.name"), D(), Le();
+Et.push(m.watch(N.virtualMachine, r, function(e) {
+B.virtualMachines = e.by("metadata.name"), A(), Le();
 }, {
 poll: V,
 pollInterval: 6e4
@@ -526,20 +537,20 @@ return be.servicePlans[t] = e, e;
 }).finally(function() {
 delete v[t];
 })), v[t]);
-}, Rt.push(m.watch(le, r, function(e) {
+}, Et.push(m.watch(le, r, function(e) {
 be.serviceInstances = e.by("metadata.name");
 var t = [];
 _.each(be.serviceInstances, function(e) {
 var n = R.getServiceInstanceAlerts(e);
 xe(e, n), t.push(p(e)), t.push(f(e));
 }), I.waitForAll(t).finally(function() {
-It(), Le();
+Rt(), Le();
 }), et(be.serviceInstances);
 }, {
 poll: V,
 pollInterval: 6e4
-}))), u.SERVICE_CATALOG_ENABLED && U(se, "watch") && Rt.push(m.watch(se, r, function(e) {
-be.bindings = e.by("metadata.name"), B.bindingsByInstanceRef = _.groupBy(be.bindings, "spec.instanceRef.name"), kt();
+}))), u.SERVICE_CATALOG_ENABLED && U(se, "watch") && Et.push(m.watch(se, r, function(e) {
+be.bindings = e.by("metadata.name"), B.bindingsByInstanceRef = _.groupBy(be.bindings, "spec.instanceRef.name"), It();
 }, {
 poll: V,
 pollInterval: 6e4
@@ -554,7 +565,7 @@ errorNotification: !1
 }).then(function(t) {
 B.samplePipelineURL = w.createFromTemplateURL(t, e.projectName);
 }), e.$on("$destroy", function() {
-m.unwatchAll(Rt), $(window).off(".overview");
+m.unwatchAll(Et), $(window).off(".overview");
 });
 }), function(t) {
 L && _.get(t, "notFound") && (f.notifyInvalidProjectHomePage(e.projectName), w.toProjectList());
@@ -3335,6 +3346,51 @@ filterForOwner: function(t, n) {
 return e.filterForController(t, n);
 }
 };
+} ]), angular.module("openshiftConsole").factory("RdpService", [ "Logger", function(e) {
+function t(e, t) {
+var n = _.get(e, "spec.ports");
+return _.find(n, {
+targetPort: t
+});
+}
+return {
+buildRdp: function(e, t) {
+return "full address:s:" + e + ":" + t + "\nusername:s:Administrator\nscreen mode id:i:2\nprompt for credentials:i:1\ndesktopwidth:i:0\ndesktopheight:i:0\nauthentication level:i:2\nredirectclipboard:i:1\nsession bpp:i:32\ncompression:i:1\nkeyboardhook:i:2\naudiocapturemode:i:0\nvideoplaybackmode:i:1\nconnection type:i:2\ndisplayconnectionbar:i:1\ndisable wallpaper:i:1\nallow font smoothing:i:1\nallow desktop composition:i:0\ndisable full window drag:i:1\ndisable menu anims:i:1\ndisable themes:i:0\ndisable cursor setting:i:0\nbitmapcachepersistenable:i:1\naudiomode:i:0\nredirectcomports:i:0\nredirectposdevices:i:0\nredirectdirectx:i:1\nautoreconnection enabled:i:1\nnegotiate security layer:i:1\nremoteapplicationmode:i:0\nalternate shell:s:\nshell working directory:s:\ngatewayhostname:s:\ngatewayusagemethod:i:4\ngatewaycredentialssource:i:4\ngatewayprofileusagemethod:i:0\npromptcredentialonce:i:1\nuse redirection server name:i:0\n";
+},
+fileDownload: function(e, t, n) {
+t = t || "vm.rdp", n = n || "application/rdp";
+var r = new Blob([ e ], {
+type: n
+});
+saveAs(r, t);
+},
+findRDPPort: t,
+getAddressPort: function(n, r, a) {
+var o = t(n, a);
+if (!o) return null;
+var i, s = _.get(n, "spec.type"), c = _.get(o, "port");
+switch (s) {
+case "LoadBalancer":
+if (!(i = _.get(n, "spec.externalIPs[0]"))) return e.warn("External IP is not defined for the LoadBalancer RDP Service: ", n, r), null;
+break;
+
+case "ClusterIP":
+if (!(i = _.get(n, "spec.clusterIP"))) return e.warn("Cluster IP is not defined for the ClusterIP RDP Service: ", n, r), null;
+break;
+
+case "NodePort":
+if (!(i = _.get(r, "_pod.status.hostIP"))) return e.warn("Node IP (pod.status.hostIP) is not yet known, using NodePort RDP Service: ", n, r), null;
+break;
+
+default:
+return console.error("Unrecognized Service type: ", n), null;
+}
+return e.info("RDP requested for: ", i, c, s), {
+address: i,
+port: c
+};
+}
+};
 } ]), angular.module("openshiftConsole").service("CachedTemplateService", function() {
 var e = null;
 return {
@@ -4989,7 +5045,7 @@ name: e.containerName
 }), n = I(t);
 e.containerState = n;
 });
-}, N = e("annotation"), A = function(e, t) {
+}, N = e("annotation"), D = function(e, t) {
 if (r.loaded = !0, r.pod = e, r.dcName = N(e, "deploymentConfig"), r.rcName = N(e, "deployment"), r.deploymentVersion = N(e, "deploymentVersion"), r.logCanRun = !_.includes([ "New", "Pending", "Unknown" ], e.status.phase), S(), delete r.controllerRef, !r.dcName) {
 var n = m.getControllerReferences(e);
 r.controllerRef = _.find(n, function(e) {
@@ -5005,10 +5061,10 @@ f.get(n.project).then(_.spread(function(t, a) {
 b = a, r.project = t, r.projectContext = a, s.get(r.podsVersion, n.pod, a, {
 errorNotification: !1
 }).then(function(e) {
-A(e);
+D(e);
 var t = {};
 t[e.metadata.name] = e, r.logOptions.container = n.container || e.spec.containers[0].name, r.containerTerminals = R(), E(e), l.fetchReferencedImageStreamImages(t, r.imagesByDockerReference, r.imageStreamImageRefByDockerReference, b), h.push(s.watchObject(r.podsVersion, n.pod, a, function(e, t) {
-A(e, t), T(r.containerTerminals), E(e);
+D(e, t), T(r.containerTerminals), E(e);
 }));
 }, function(t) {
 r.loaded = !0, r.alerts.load = {
@@ -5209,12 +5265,12 @@ n.filteredStatefulSets = c.filterForKeywords(_.values(n.statefulSets), P, j);
 C = _.filter(n.pods, function(e) {
 return !n.filters.hideOlderResources || "Succeeded" !== e.status.phase && "Failed" !== e.status.phase;
 }), n.filteredPods = c.filterForKeywords(C, P, j);
-}, A = r("isIncompleteBuild"), D = r("buildConfigForBuild"), B = r("isRecentBuild"), V = function() {
+}, D = r("isIncompleteBuild"), A = r("buildConfigForBuild"), B = r("isRecentBuild"), V = function() {
 moment().subtract(5, "m");
 y = _.filter(n.builds, function(e) {
 if (!n.filters.hideOlderResources) return !0;
-if (A(e)) return !0;
-var t = D(e);
+if (D(e)) return !0;
+var t = A(e);
 return t ? n.latestBuildByConfig[t].metadata.name === e.metadata.name : B(e);
 }), n.filteredBuilds = c.filterForKeywords(y, P, j);
 }, L = r("deploymentStatus"), O = r("deploymentIsInProgress"), U = function() {
@@ -5426,7 +5482,7 @@ return e ? r + (y(e, "description") || "") : "";
 }
 }
 });
-var A = function(e, t, n, a) {
+var D = function(e, t, n, a) {
 var o = {
 title: "Confirm Removal",
 alerts: {},
@@ -5473,7 +5529,7 @@ project: n,
 subjectKinds: N,
 canUpdateRolebindings: b("rolebindings", "update", v),
 confirmRemove: function(n, a, i, s) {
-var l = null, u = A(n, a, i, r.user.metadata.name);
+var l = null, u = D(n, a, i, r.user.metadata.name);
 _.isEqual(n, r.user.metadata.name) && d.isLastRole(r.user.metadata.name, r.roleBindings) && (l = !0), o.open({
 templateUrl: "views/modals/confirm.html",
 controller: "ConfirmModalController",
@@ -6212,7 +6268,7 @@ o.unwatchAll(j);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("ReplicaSetController", [ "$scope", "$filter", "$routeParams", "APIService", "AuthorizationService", "BreadcrumbsService", "DataService", "DeploymentsService", "HPAService", "ImageStreamResolver", "keyValueEditorUtils", "kind", "Logger", "MetricsService", "ModalsService", "Navigate", "OwnerReferencesService", "PodsService", "ProjectsService", "StorageService", function(e, t, n, r, a, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b) {
-var S = !1, C = t("annotation"), w = t("humanizeKind")(d), P = t("hasDeployment"), j = r.getPreferredVersion("builds"), k = r.getPreferredVersion("imagestreams"), I = r.getPreferredVersion("horizontalpodautoscalers"), R = r.getPreferredVersion("limitranges"), E = r.getPreferredVersion("pods"), T = r.getPreferredVersion("replicasets"), N = r.getPreferredVersion("replicationcontrollers"), A = r.getPreferredVersion("resourcequotas"), D = r.getPreferredVersion("appliedclusterresourcequotas");
+var S = !1, C = t("annotation"), w = t("humanizeKind")(d), P = t("hasDeployment"), j = r.getPreferredVersion("builds"), k = r.getPreferredVersion("imagestreams"), I = r.getPreferredVersion("horizontalpodautoscalers"), R = r.getPreferredVersion("limitranges"), E = r.getPreferredVersion("pods"), T = r.getPreferredVersion("replicasets"), N = r.getPreferredVersion("replicationcontrollers"), D = r.getPreferredVersion("resourcequotas"), A = r.getPreferredVersion("appliedclusterresourcequotas");
 switch (d) {
 case "ReplicaSet":
 e.resource = T, e.healthCheckURL = g.healthCheckURL(n.project, "ReplicaSet", n.replicaSet, "extensions");
@@ -6360,12 +6416,12 @@ pollInterval: 6e4
 })), i.list(R, u).then(function(t) {
 e.limitRanges = t.by("metadata.name"), U();
 });
-B.push(i.watch(A, u, function(t) {
+B.push(i.watch(D, u, function(t) {
 e.quotas = t.by("metadata.name");
 }, {
 poll: !0,
 pollInterval: 6e4
-})), B.push(i.watch(D, u, function(t) {
+})), B.push(i.watch(A, u, function(t) {
 e.clusterQuotas = t.by("metadata.name");
 }, {
 poll: !0,
@@ -7269,7 +7325,7 @@ return _.map(e, "metadata.name");
 });
 e.webhookSecrets = m.groupSecretsByType(t).webhook, e.webhookSecrets.unshift(""), e.secrets.secretsByType = _.each(r, function(e) {
 e.unshift("");
-}), A(), P = S(t.by("metadata.name")), e.valueFromObjects = w.concat(P);
+}), D(), P = S(t.by("metadata.name")), e.valueFromObjects = w.concat(P);
 });
 var n = function(e, n) {
 e.type = n && n.kind ? n.kind : "None";
@@ -7416,7 +7472,7 @@ var t = [].concat(e.triggers.imageChangeTriggers, e.triggers.builderImageChangeT
 return t = _.filter(t, function(e) {
 return _.has(e, "disabled") && !e.disabled || e.present;
 }), t = t.concat(T(e.triggers.webhookTriggers)), t = _.map(t, "data");
-}, A = function() {
+}, D = function() {
 switch (e.secrets.picked = {
 gitSecret: e.buildConfig.spec.source.sourceSecret ? [ e.buildConfig.spec.source.sourceSecret ] : [ {
 name: ""
@@ -7446,7 +7502,7 @@ name: ""
 mountPath: ""
 } ];
 }
-}, D = function(e, t, n) {
+}, A = function(e, t, n) {
 t.name ? e[n] = t : delete e[n];
 }, $ = function(t, n) {
 var r = "Custom" === e.strategyType ? "secretSource" : "secret", a = _.filter(n, function(e) {
@@ -7467,7 +7523,7 @@ break;
 case "JenkinsPipeline":
 "path" === e.jenkinsfileOptions.type ? delete e.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile : delete e.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath;
 }
-switch (e.sources.images && !_.isEmpty(e.sourceImages) && (e.updatedBuildConfig.spec.source.images[0].paths = R(e.imageSourcePaths), e.updatedBuildConfig.spec.source.images[0].from = E(e.imageOptions.fromSource)), "None" === e.imageOptions.from.type ? delete b(e.updatedBuildConfig).from : b(e.updatedBuildConfig).from = E(e.imageOptions.from), "None" === e.imageOptions.to.type ? delete e.updatedBuildConfig.spec.output.to : e.updatedBuildConfig.spec.output.to = E(e.imageOptions.to), b(e.updatedBuildConfig).env = p.compactEntries(e.envVars), D(e.updatedBuildConfig.spec.source, _.head(e.secrets.picked.gitSecret), "sourceSecret"), D(b(e.updatedBuildConfig), _.head(e.secrets.picked.pullSecret), "pullSecret"), D(e.updatedBuildConfig.spec.output, _.head(e.secrets.picked.pushSecret), "pushSecret"), e.strategyType) {
+switch (e.sources.images && !_.isEmpty(e.sourceImages) && (e.updatedBuildConfig.spec.source.images[0].paths = R(e.imageSourcePaths), e.updatedBuildConfig.spec.source.images[0].from = E(e.imageOptions.fromSource)), "None" === e.imageOptions.from.type ? delete b(e.updatedBuildConfig).from : b(e.updatedBuildConfig).from = E(e.imageOptions.from), "None" === e.imageOptions.to.type ? delete e.updatedBuildConfig.spec.output.to : e.updatedBuildConfig.spec.output.to = E(e.imageOptions.to), b(e.updatedBuildConfig).env = p.compactEntries(e.envVars), A(e.updatedBuildConfig.spec.source, _.head(e.secrets.picked.gitSecret), "sourceSecret"), A(b(e.updatedBuildConfig), _.head(e.secrets.picked.pullSecret), "pullSecret"), A(e.updatedBuildConfig.spec.output, _.head(e.secrets.picked.pushSecret), "pushSecret"), e.strategyType) {
 case "Source":
 case "Docker":
 $(e.updatedBuildConfig.spec.source, e.secrets.picked.sourceSecrets);
@@ -8133,13 +8189,13 @@ g.hideNotification("create-builder-list-config-maps-error"), g.hideNotification(
 });
 };
 e.$on("$destroy", N);
-var A = i.getPreferredVersion("configmaps"), D = i.getPreferredVersion("limitranges"), $ = i.getPreferredVersion("imagestreams"), B = i.getPreferredVersion("imagestreamtags"), V = i.getPreferredVersion("secrets"), L = i.getPreferredVersion("resourcequotas"), O = i.getPreferredVersion("appliedclusterresourcequotas");
+var D = i.getPreferredVersion("configmaps"), A = i.getPreferredVersion("limitranges"), $ = i.getPreferredVersion("imagestreams"), B = i.getPreferredVersion("imagestreamtags"), V = i.getPreferredVersion("secrets"), L = i.getPreferredVersion("resourcequotas"), O = i.getPreferredVersion("appliedclusterresourcequotas");
 v.get(a.project).then(_.spread(function(t, n) {
 e.project = t, a.sourceURI && (e.sourceURIinParams = !0), e.hasClusterResourceOverrides = d.hasClusterResourceOverrides(t);
 var i = function() {
 e.cpuProblems = d.validatePodLimits(e.limitRanges, "cpu", [ e.container ], t), e.memoryProblems = d.validatePodLimits(e.limitRanges, "memory", [ e.container ], t);
 };
-c.list(D, n).then(function(t) {
+c.list(A, n).then(function(t) {
 e.limitRanges = t.by("metadata.name"), _.isEmpty(e.limitRanges) || e.$watch("container", i, !0);
 });
 var v, y, C = function() {
@@ -8191,7 +8247,7 @@ return r.buildConfig.sourceUrl === _.get(r, "image.metadata.annotations.sampleRe
 e.metricsWarning = !t;
 });
 var o = [], i = [];
-e.valueFromObjects = [], c.list(A, n, null, {
+e.valueFromObjects = [], c.list(D, n, null, {
 errorNotification: !1
 }).then(function(t) {
 o = R(t.by("metadata.name")), e.valueFromObjects = o.concat(i);
@@ -9890,9 +9946,9 @@ details: e("getErrorDetails")(n)
 }
 function w() {
 var e = {
-started: "Creating resources in project " + D(p.input.selectedProject),
-success: "Creating resources in project " + D(p.input.selectedProject),
-failure: "Failed to create some resources in project " + D(p.input.selectedProject)
+started: "Creating resources in project " + A(p.input.selectedProject),
+success: "Creating resources in project " + A(p.input.selectedProject),
+failure: "Failed to create some resources in project " + A(p.input.selectedProject)
 }, t = {};
 d.add(e, t, p.input.selectedProject.metadata.name, function() {
 var e = n.defer();
@@ -9927,9 +9983,9 @@ hasErrors: r
 }
 function P() {
 var e = {
-started: "Updating resources in project " + D(p.input.selectedProject),
-success: "Updated resources in project " + D(p.input.selectedProject),
-failure: "Failed to update some resources in project " + D(p.input.selectedProject)
+started: "Updating resources in project " + A(p.input.selectedProject),
+success: "Updated resources in project " + A(p.input.selectedProject),
+failure: "Failed to update some resources in project " + A(p.input.selectedProject)
 }, t = {};
 d.add(e, t, p.input.selectedProject.metadata.name, function() {
 var e = n.defer();
@@ -10012,7 +10068,7 @@ type: "error"
 }).length ? (_.each(E, function(e) {
 e.id = _.uniqueId("from-file-alert-"), c.addNotification(e);
 }), p.disableInputs = !1) : E.length ? (R(E), p.disableInputs = !1) : y();
-}, A = function() {
+}, D = function() {
 if (_.has(p.input.selectedProject, "metadata.uid")) return n.when(p.input.selectedProject);
 var t = p.input.selectedProject.metadata.name, r = p.input.selectedProject.metadata.annotations["new-display-name"], a = e("description")(p.input.selectedProject);
 return m.create(t, r, a);
@@ -10027,7 +10083,7 @@ var e = [];
 p.errorOccurred = !1, _.forEach(p.resourceList, function(t) {
 if (!g(t)) return p.errorOccurred = !0, !1;
 e.push(S(t));
-}), A().then(function(t) {
+}), D().then(function(t) {
 p.input.selectedProject = t, n.all(e).then(function() {
 p.errorOccurred || (1 === p.createResources.length && "Template" === p.resourceList[0].kind ? v() : _.isEmpty(p.updateResources) ? l.getLatestQuotaAlerts(p.createResources, {
 namespace: p.input.selectedProject.metadata.name
@@ -10045,7 +10101,7 @@ details: I(e)
 }, p.cancel = function() {
 T(), s.toProjectOverview(p.input.selectedProject.metadata.name);
 };
-var D = e("displayName");
+var A = e("displayName");
 p.$on("importFileFromYAMLOrJSON", p.create), p.$on("$destroy", T);
 } ]
 };
@@ -10924,11 +10980,11 @@ _.size(h) <= 100 ? (y = e("orderByDisplayName")(h), T = _.map(y, function(e) {
 return n(e, !1);
 })) : T = [ n(h[t], !0) ], E.empty(), E.append(T), E.append($('<option data-divider="true"></option>')), E.append($('<option value="">View All Projects</option>')), E.selectpicker("refresh");
 }
-}, A = function() {
+}, D = function() {
 return f.list().then(function(e) {
 h = e.by("metadata.name");
 });
-}, D = function() {
+}, A = function() {
 k(R);
 var e = a.project;
 if (i.currentProjectName !== e) {
@@ -10945,7 +11001,7 @@ n.all([ r, a ]).then(function() {
 i.catalogItems = c.sortCatalogItems(_.concat(t, o));
 });
 }
-}), A().then(function() {
+}), D().then(function() {
 i.currentProjectName && h && (h[i.currentProjectName] || (h[i.currentProjectName] = {
 metadata: {
 name: i.currentProjectName
@@ -10985,7 +11041,7 @@ m.toProjectCatalog(i.currentProjectName, n);
 });
 i.closeOrderingPanel = function() {
 v.addItem(_.get(i.selectedItem, "resource.metadata.uid")), i.orderingPanelVisible = !1;
-}, D(), i.$on("$routeChangeSuccess", D), E.change(function() {
+}, A(), i.$on("$routeChangeSuccess", A), E.change(function() {
 var e = $(this).val(), t = "" === e ? "projects" : g(e);
 I(t);
 }), i.$on("$destroy", function() {
@@ -11981,7 +12037,7 @@ Available: "#d1d1d1"
 }
 };
 R[t.id] ? R[t.id].load(a) : ((n = B(e)).data = a, r(function() {
-D || (R[t.id] = c3.generate(n));
+A || (R[t.id] = c3.generate(n));
 }));
 }
 }
@@ -11997,7 +12053,7 @@ var n, a = c.getSparklineData(t), o = e.chartPrefix + "sparkline";
 E[o] ? E[o].load(a) : ((n = V(e)).data = a, e.chartDataColors && (n.color = {
 pattern: e.chartDataColors
 }), r(function() {
-D || (E[o] = c3.generate(n));
+A || (E[o] = c3.generate(n));
 }));
 }
 }
@@ -12008,7 +12064,7 @@ function h() {
 return 60 * m.options.timeRange.value * 1e3;
 }
 function y() {
-return Math.floor(h() / A) + "ms";
+return Math.floor(h() / D) + "ms";
 }
 function b(e, t, n) {
 var r, a = {
@@ -12023,12 +12079,12 @@ containerName: e.containerMetric ? m.options.selectedContainer.name : "pod"
 }) : null;
 }
 function S() {
-D || (L = 0, _.each(m.metrics, function(e) {
+A || (L = 0, _.each(m.metrics, function(e) {
 g(e), f(e);
 }));
 }
 function C(e) {
-if (!D) if (L++, m.noData) m.metricsError = {
+if (!A) if (L++, m.noData) m.metricsError = {
 status: _.get(e, "status", 0),
 details: _.get(e, "data.errorMsg") || _.get(e, "statusText") || "Status code " + _.get(e, "status", 0)
 }; else if (!(L < 2)) {
@@ -12057,7 +12113,7 @@ isNaN(r) && (r = 0), e.convert && (r = e.convert(r)), t.used = d3.round(r, e.usa
 function j(e, t) {
 m.noData = !1;
 var n = _.initial(t.data);
-e.data ? e.data = _.chain(e.data).takeRight(A).concat(n).value() : e.data = n;
+e.data ? e.data = _.chain(e.data).takeRight(D).concat(n).value() : e.data = n;
 }
 function k() {
 if (w()) {
@@ -12073,7 +12129,7 @@ P(n, a, e);
 }));
 }
 }), t = t.concat(r), a.all(r).then(function(e) {
-D || angular.forEach(e, function(e) {
+A || angular.forEach(e, function(e) {
 e && j(_.find(n.datasets, {
 id: e.metricID
 }), e);
@@ -12085,7 +12141,7 @@ m.loaded = !0;
 }
 }
 m.includedMetrics = m.includedMetrics || [ "cpu", "memory", "network" ];
-var I, R = {}, E = {}, T = n("resources.limits.memory"), N = n("resources.limits.cpu"), A = 30, D = !1;
+var I, R = {}, E = {}, T = n("resources.limits.memory"), N = n("resources.limits.cpu"), D = 30, A = !1;
 m.uniqueID = c.uniqueID(), m.metrics = [], _.includes(m.includedMetrics, "memory") && m.metrics.push({
 label: "Memory",
 units: "MiB",
@@ -12189,7 +12245,7 @@ I && (t.cancel(I), I = null), O && (O(), O = null), angular.forEach(R, function(
 e.destroy();
 }), R = null, angular.forEach(E, function(e) {
 e.destroy();
-}), E = null, D = !0;
+}), E = null, A = !0;
 });
 }
 };
@@ -12251,7 +12307,7 @@ return e[0];
 function u(e) {
 P || (N = 0, t.showAverage = _.size(t.pods) > 5 || w, _.each(t.metrics, function(n) {
 var r, a = o(e, n), i = n.descriptor;
-w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (T[i].lastValue = (T[i].lastValue || 0) + n.lastValue)), S[i] ? (S[i].load(a), t.showAverage ? S[i].legend.hide() : S[i].legend.show()) : ((r = A(n)).data = a, S[i] = c3.generate(r));
+w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (T[i].lastValue = (T[i].lastValue || 0) + n.lastValue)), S[i] ? (S[i].load(a), t.showAverage ? S[i].legend.hide() : S[i].legend.show()) : ((r = D(n)).data = a, S[i] = c3.generate(r));
 }));
 }
 function d() {
@@ -12381,7 +12437,7 @@ t.metricsURL = e;
 }), t.options = {
 rangeOptions: s.getTimeRangeOptions()
 }, t.options.timeRange = _.head(t.options.rangeOptions), t.options.selectedContainer = _.head(t.containers);
-var A = function(e) {
+var D = function(e) {
 var n = s.getDefaultSparklineConfig(e.chartID, e.units, w);
 return _.set(n, "legend.show", !w && !t.showAverage), n;
 };
@@ -12390,11 +12446,11 @@ I = {}, j = null, delete t.metricsError, y();
 }, !0), b = e(y, s.getDefaultUpdateInterval(), !1), t.updateInView = function(e) {
 R = !e, e && (!k || Date.now() > k + s.getDefaultUpdateInterval()) && y();
 };
-var D = a.$on("metrics.charts.resize", function() {
+var A = a.$on("metrics.charts.resize", function() {
 s.redraw(S);
 });
 t.$on("$destroy", function() {
-b && (e.cancel(b), b = null), D && (D(), D = null), angular.forEach(S, function(e) {
+b && (e.cancel(b), b = null), A && (A(), A = null), angular.forEach(S, function(e) {
 e.destroy();
 }), S = null, P = !0;
 });
@@ -12473,17 +12529,17 @@ k(!0), b(), C();
 m.on("resize", R);
 var E, T = function() {
 S = !0, d.scrollBottom(u);
-}, N = document.createDocumentFragment(), A = _.debounce(function() {
+}, N = document.createDocumentFragment(), D = _.debounce(function() {
 l.appendChild(N), N = document.createDocumentFragment(), t.autoScrollActive && T(), t.showScrollLinks || b();
 }, 100, {
 maxWait: 300
-}), D = function(e) {
+}), A = function(e) {
 var t = a.defer();
 return E ? (E.onClose(function() {
 t.resolve();
-}), E.stop()) : t.resolve(), e || (A.cancel(), l && (l.innerHTML = ""), N = document.createDocumentFragment()), t.promise;
+}), E.stop()) : t.resolve(), e || (D.cancel(), l && (l.innerHTML = ""), N = document.createDocumentFragment()), t.promise;
 }, B = function() {
-D().then(function() {
+A().then(function() {
 t.$evalAsync(function() {
 if (t.run) {
 angular.extend(t, {
@@ -12499,14 +12555,14 @@ follow: !0,
 tailLines: 5e3,
 limitBytes: 10485760
 }, t.options), n = 0, r = function(e) {
-n++, N.appendChild(f(n, e)), A();
+n++, N.appendChild(f(n, e)), D();
 };
 (E = c.createStream(v, h, t.context, e)).onMessage(function(a, o, i) {
 t.$evalAsync(function() {
 t.empty = !1, "logs" !== t.state && (t.state = "logs", I());
 }), a && (e.limitBytes && i >= e.limitBytes && (t.$evalAsync(function() {
 t.limitReached = !0, t.loading = !1;
-}), D(!0)), r(a), !t.largeLog && n >= e.tailLines && t.$evalAsync(function() {
+}), A(!0)), r(a), !t.largeLog && n >= e.tailLines && t.$evalAsync(function() {
 t.largeLog = !0;
 }));
 }), E.onClose(function() {
@@ -12566,7 +12622,7 @@ t.autoScrollActive = !t.autoScrollActive, t.autoScrollActive && T();
 goChromeless: d.chromelessLink,
 restartLogs: B
 }), t.$on("$destroy", function() {
-D(), m.off("resize", R), m.off("scroll", C), u && $(u).off("scroll", C);
+A(), m.off("resize", R), m.off("scroll", C), u && $(u).off("scroll", C);
 }), "deploymentconfigs/logs" === v && !h) return t.state = "empty", void (t.emptyStateMessage = "Logs are not available for this replication controller because it was not generated from a deployment configuration.");
 t.$watchGroup([ "name", "options.container", "run" ], B);
 } ],
@@ -14117,33 +14173,48 @@ templateUrl: "views/overview/_mobile-client-row.html"
 });
 }(), function() {
 angular.module("openshiftConsole").component("virtualMachineRow", {
-controller: [ "$scope", "$filter", "$routeParams", "APIService", "AuthorizationService", "DataService", "ListRowUtils", "Navigate", "ProjectsService", "KubevirtVersions", "moment", function(e, t, n, r, a, o, i, s, c, l, u) {
-function d() {
-return f.apiObject.spec.running;
-}
-function m() {
-var e = angular.copy(f.apiObject);
+controller: [ "$scope", "$filter", "$routeParams", "APIService", "AuthorizationService", "DataService", "ListRowUtils", "Navigate", "ProjectsService", "KubevirtVersions", "moment", "RdpService", function(t, n, r, a, o, i, s, c, l, u, d, m) {
+function p() {
+var e = angular.copy(g.apiObject);
 return delete e._pod, delete e._vm, e;
 }
-function p(t) {
-var n = m();
-return n.spec.running = t, o.update(l.offlineVirtualMachine.resource, n.metadata.name, n, e.$parent.context);
+function f(e) {
+var n = p();
+return n.spec.running = e, i.update(u.offlineVirtualMachine.resource, n.metadata.name, n, t.$parent.context);
 }
-var f = this;
-f.OfflineVirtualMachineVersion = l.offlineVirtualMachine, _.extend(f, i.ui), f.actionsDropdownVisible = function() {
-return !_.get(f.apiObject, "metadata.deletionTimestamp") && a.canI(l.offlineVirtualMachine, "delete");
-}, f.projectName = n.project, f.startOvm = function() {
-p(!0);
-}, f.stopOvm = function() {
-p(!1);
-}, f.restartOvm = function() {
-return o.delete(l.virtualMachine, f.apiObject._vm.metadata.name, e.$parent.context);
-}, f.canStartOvm = function() {
-return !d();
-}, f.canStopOvm = function() {
-return d();
-}, f.canRestartOvm = function() {
-return d() && f.apiObject._vm && "Running" === _.get(f.apiObject, "_pod.status.phase");
+var g = this;
+g.OfflineVirtualMachineVersion = u.offlineVirtualMachine, _.extend(g, s.ui), g.actionsDropdownVisible = function() {
+return !_.get(g.apiObject, "metadata.deletionTimestamp") && o.canI(u.offlineVirtualMachine, "delete");
+}, g.projectName = r.project, g.isOvmRunning = function() {
+return g.apiObject.spec.running;
+}, g.isOvmInRunningPhase = function() {
+return g.isOvmRunning() && g.apiObject._vm && "Running" === _.get(g.apiObject, "_pod.status.phase");
+}, g.startOvm = function() {
+f(!0);
+}, g.stopOvm = function() {
+f(!1);
+}, g.restartOvm = function() {
+return i.delete(u.virtualMachine, g.apiObject._vm.metadata.name, t.$parent.context);
+}, g.canStartOvm = function() {
+return !g.isOvmRunning();
+}, g.canStopOvm = function() {
+return g.isOvmRunning();
+}, g.canRestartOvm = function() {
+return g.isOvmInRunningPhase();
+}, g.isWindowsVM = function() {
+var e = g.apiObject, t = g.apiObject._vm, n = _.get(t, [ "metadata", "labels", "kubevirt.io/os" ]) || _.get(e, [ "metadata", "labels", "kubevirt.io/os" ]);
+return n && _.startsWith(n, "win");
+}, g.isRdpService = function() {
+var e = g.apiObject;
+return !_.isEmpty(e.services);
+}, g.onOpenRemoteDesktop = function() {
+var t = g.apiObject;
+if (!_.isEmpty(t.services)) {
+var n = _.find(t.services, function(t) {
+return m.findRDPPort(t, e);
+}), r = m.getAddressPort(n, t, e);
+r && m.fileDownload(m.buildRdp(r.address, r.port));
+}
 };
 } ],
 controllerAs: "row",
@@ -14152,7 +14223,9 @@ apiObject: "<",
 state: "<"
 },
 templateUrl: "views/overview/_virtual-machine-row.html"
-}), angular.module("openshiftConsole").filter("vmPodUptime", function() {
+});
+var e = 3389;
+angular.module("openshiftConsole").filter("vmPodUptime", function() {
 return function(e) {
 var t = _(_.get(e, "status.containerStatuses")).filter({
 name: "compute"
@@ -14766,7 +14839,7 @@ cancelButtonText: "Cancel"
 }
 }
 }).result.then(T);
-}, A = function(e) {
+}, D = function(e) {
 b = e.quotaAlerts || [];
 var t = _.filter(b, {
 type: "error"
@@ -14783,7 +14856,7 @@ namespace: n.input.selectedProject.metadata.name
 }), i = function(e) {
 return n.nameTaken = e.nameTaken, r;
 };
-t.then(i, i).then(A, A);
+t.then(i, i).then(D, D);
 }, function(e) {
 n.disableInputs = !1, "AlreadyExists" === e.data.reason ? n.projectNameTaken = !0 : l.addNotification({
 id: "deploy-image-create-project-error",
@@ -15255,7 +15328,7 @@ namespace: e.namespace
 S[a.project] && delete S[a.project][e.uid], b[a.project] && delete b[a.project][e.uid], E(e);
 }, N = function() {
 b[a.project] = {}, S[a.project] = {};
-}, A = function(e) {
+}, D = function(e) {
 return _.reduce(e, function(e, t) {
 return e[t.metadata.uid] = {
 actions: null,
@@ -15268,7 +15341,7 @@ firstTimestamp: t.firstTimestamp,
 event: t
 }, e;
 }, {});
-}, D = function(e) {
+}, A = function(e) {
 return _.reduce(e, function(e, t) {
 return u.isImportantAPIEvent(t) && !u.isCleared(t.metadata.uid) && (e[t.metadata.uid] = t), e;
 }, {});
@@ -15290,7 +15363,7 @@ m && (l.unwatch(m), m = null);
 }, U = function() {
 d && d(), d = null;
 }, F = function(e) {
-b[a.project] = A(D(e.by("metadata.name"))), V();
+b[a.project] = D(A(e.by("metadata.name"))), V();
 }, x = function(e, t) {
 var n = t.namespace || a.project, r = t.id ? n + "/" + t.id : _.uniqueId("notification_") + Date.now();
 t.showInDrawer && !u.isCleared(r) && (S[n] = S[n] || {}, S[n][r] = {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -13071,6 +13071,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"vm-detail-key\">Uptime:</span>\n" +
     "<span class=\"vm-detail-value\">{{ row.apiObject._pod | vmPodUptime }}</span>\n" +
     "</div>\n" +
+    "<div class=\"word-break\" ng-if=\"row.isWindowsVM() && row.isOvmInRunningPhase()\">\n" +
+    "<span class=\"vm-detail-key\">Remote Desktop:</span>\n" +
+    "<span class=\"vm-detail-value\">\n" +
+    "<a href=\"\" ng-if=\"row.isRdpService()\" ng-click=\"row.onOpenRemoteDesktop()\">Open Console</a>\n" +
+    "<div ng-if=\"!row.isRdpService()\">No RDP service defined</div>\n" +
+    "</span>\n" +
+    "</div>\n" +
     "<div class=\"word-break\">\n" +
     "<span class=\"vm-detail-key\">Operating System:</span>\n" +
     "<span class=\"vm-detail-value\">{{row.apiObject.metadata.labels['kubevirt.io/os'] || '--'}}</span>\n" +


### PR DESCRIPTION
Latest version of https://github.com/openshift/origin-web-console/pull/2966

---

Link to download an RDP file to access Windows VM is added.
Mime-type of downloaded content is "application/rdp".

Requires LoadBalancer Service object exposing VM ports [1].
The Service.spec.selector["kubevirt.io/domain"] is expected
to match OVM.metadata.labels["kubevirt.io/domain"].

The RDP link is rendered if:
- matching Service is defined
- VM is running
- VM is Windows (OVM.metadata.labels["kubevirt.io/domain"] starts at "win")

If Service object can not be found, but the VM is Windows and running,
informative text about missing Service is rendered instead of the link.

The Service object exposing IP:Port should conform [1].
In a nutshell, the IP:Port is determined for Service type of:
- NodePort:
  - port = Service.spec.port[].nodePort
  - IP = nodeIP of node the VM is scheduled to (conforms pod.spec.hostIP)
- ClusterIP
  - port = Service.spec.port[].port
  - IP = Service.spec.clusterIP
- LoadBalancer
  - port = Service.spec.port[].port
  - IP = Service.spec.externalIP[0]

The Service is expected to map 3389 port to one of the above.

VM operating system is determined from "kubevirt.io/os" label of
the running OfflineVirtualMachine object.

[1] https://github.com/kubevirt/user-guide/blob/master/workloads/virtual-machines/expose-service.md