### PR TITLE
Fix wording for timestamp

### DIFF
--- a/app/views/browse/virtual-machine-instance.html
+++ b/app/views/browse/virtual-machine-instance.html
@@ -31,7 +31,7 @@
             </ul>
           </div>
           {{vmi.metadata.name}}
-          <small class="meta">created {{vmi.metadata.creationTimestamp | amTimeAgo}}</small>
+          <small class="meta">created {{vmi.metadata.creationTimestamp | amTimeAgo + ' ago'}}</small>
           <small class="meta" ng-if="vm.metadata.deletionTimestamp">(expires {{vm.metadata.deletionTimestamp | date : 'medium'}})</small>
         </h1>
         <labels labels="vmi.metadata.labels"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4087,7 +4087,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</ul>\n" +
     "</div>\n" +
     "{{vmi.metadata.name}}\n" +
-    "<small class=\"meta\">created {{vmi.metadata.creationTimestamp | amTimeAgo}}</small>\n" +
+    "<small class=\"meta\">created {{vmi.metadata.creationTimestamp | amTimeAgo + ' ago'}}</small>\n" +
     "<small class=\"meta\" ng-if=\"vm.metadata.deletionTimestamp\">(expires {{vm.metadata.deletionTimestamp | date : 'medium'}})</small>\n" +
     "</h1>\n" +
     "<labels labels=\"vmi.metadata.labels\" clickable=\"true\" kind=\"virtual-machines\" title-kind=\"Virtual machines\" project-name=\"{{vmi.metadata.namespace}}\" limit=\"3\"></labels>\n" +


### PR DESCRIPTION
On virtual-machines page, the duration since object creation is
rephrased to:

   created X hours ago

from former one:

   created X hours

Fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1593742