### PR TITLE
Fix wording for timestamp

### DIFF
--- a/app/views/browse/virtual-machine-instance.html
+++ b/app/views/browse/virtual-machine-instance.html
@@ -31,7 +31,7 @@
             </ul>
           </div>
           {{vmi.metadata.name}}
-          <small class="meta">created {{vmi.metadata.creationTimestamp | amTimeAgo + ' ago'}}</small>
+          <small class="meta">created {{vmi.metadata.creationTimestamp | amTimeAgo : true}} ago</small>
           <small class="meta" ng-if="vm.metadata.deletionTimestamp">(expires {{vm.metadata.deletionTimestamp | date : 'medium'}})</small>
         </h1>
         <labels labels="vmi.metadata.labels"

--- a/app/views/browse/virtual-machine.html
+++ b/app/views/browse/virtual-machine.html
@@ -42,7 +42,7 @@
             </ul>
           </div>
           {{vm.metadata.name}}
-          <small class="meta">created {{vm.metadata.creationTimestamp | amTimeAgo : true}}</small>
+          <small class="meta">created {{vm.metadata.creationTimestamp | amTimeAgo : true}} ago</small>
           <small class="meta" ng-if="vm.metadata.deletionTimestamp">(expires {{vm.metadata.deletionTimestamp | date : 'medium'}})</small>
         </h1>
 


### PR DESCRIPTION
Text 'ago' was missing prior this fix on Virtual Machine page.

Fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1593742