### PR TITLE
Fix passing params to vmStateText

### DIFF
--- a/app/views/browse/virtual-machine.html
+++ b/app/views/browse/virtual-machine.html
@@ -75,11 +75,11 @@
                       <dt>Virtual Machine Instance:</dt>
                       <dd>
                         <span ng-if="vmi">
-                          <span dynamic-content="{{vmi | vmStateText}}"
+                          <span dynamic-content="{{vmi | vmStateText : vm}}"
                                 data-toggle="tooltip"
                                 data-trigger="hover"
                                 aria-hidden="true">
-                            <vm-state-icon state="vmi | vmStateText"></vm-state-icon>
+                            <vm-state-icon state="vmi | vmStateText : vm"></vm-state-icon>
                             <a ng-href="{{vmi | navigateResourceURL}}">{{vmi.metadata.name}}</a>
                           </span>
                         </span>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4255,8 +4255,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt>Virtual Machine Instance:</dt>\n" +
     "<dd>\n" +
     "<span ng-if=\"vmi\">\n" +
-    "<span dynamic-content=\"{{vmi | vmStateText}}\" data-toggle=\"tooltip\" data-trigger=\"hover\" aria-hidden=\"true\">\n" +
-    "<vm-state-icon state=\"vmi | vmStateText\"></vm-state-icon>\n" +
+    "<span dynamic-content=\"{{vmi | vmStateText : vm}}\" data-toggle=\"tooltip\" data-trigger=\"hover\" aria-hidden=\"true\">\n" +
+    "<vm-state-icon state=\"vmi | vmStateText : vm\"></vm-state-icon>\n" +
     "<a ng-href=\"{{vmi | navigateResourceURL}}\">{{vmi.metadata.name}}</a>\n" +
     "</span>\n" +
     "</span>\n" +


### PR DESCRIPTION
Yet another occurance, the 'vm' object was not passed.

Follow-up for: #7 